### PR TITLE
Skip dimensionality reduction for H&E images

### DIFF
--- a/docker/paint_miniature.py
+++ b/docker/paint_miniature.py
@@ -207,8 +207,8 @@ def main():
     
     zarray = pull_pyramid(args.input, args.level)
     
-    if zarray.shape[3] == 3:
-        rgb_image = zarray
+    if zarray.shape[0] == 3:
+        rgb_image = np.moveaxis(zarray, 0, -1)
     else: 
         if args.remove_bg == False:
             tissue_array, mask = keep_background(zarray)

--- a/docker/paint_miniature.py
+++ b/docker/paint_miniature.py
@@ -128,6 +128,7 @@ def make_rgb_image(rgb, mask):
     rgb_image = np.zeros(rgb_shape)
     rgb_image[mask] = rgb
     return(rgb_image)
+
     
 def plot_embedding(embedding, rgb, output):
     p = Path(output)
@@ -206,20 +207,24 @@ def main():
     
     zarray = pull_pyramid(args.input, args.level)
     
-    if args.remove_bg == False:
-        tissue_array, mask = keep_background(zarray)
-    elif args.remove_bg == True:
-        tissue_array, mask = remove_background(zarray)
-    else:
-        tissue_array, mask = keep_background(zarray)
-    
-    if args.dimred == 'tsne':
-        embedding = run_tsne(tissue_array)
-    if args.dimred == 'umap':
-        embedding = run_umap(tissue_array)
+    if zarray.shape[3] == 3:
+        rgb_image = zarray
+    else: 
+        if args.remove_bg == False:
+            tissue_array, mask = keep_background(zarray)
+        elif args.remove_bg == True:
+            tissue_array, mask = remove_background(zarray)
+        else:
+            tissue_array, mask = keep_background(zarray)
         
-    rgb = assign_colours(embedding)
-    rgb_image = make_rgb_image(rgb, mask)
+        if args.dimred == 'tsne':
+            embedding = run_tsne(tissue_array)
+        if args.dimred == 'umap':
+            embedding = run_umap(tissue_array)
+            
+        rgb = assign_colours(embedding)
+        rgb_image = make_rgb_image(rgb, mask)
+     
     
     print("Saving image as " + args.output)
     output_path = "data/" + args.output


### PR DESCRIPTION
If number of channels is 3, directly render the RGB image as dimensionality reduction is not required to effectively visualise the dataset. In this PR this is just implemented for the local version, not in the S3 scripy.