### PR TITLE
Update input files for mIF example data in workflow

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -35,12 +35,12 @@ jobs:
 
     - name: 3D on mIF example data
       run: |
-        miniature data/exemplar-001_small.tif output_mif_3D.png --colormap UCIE
+        miniature data/WD-76845-003_ROI01.ome.tif output_mif_3D.png --colormap UCIE
         test -f output_mif_3D.png || (echo "mIF output file not created" && exit 1)
 
     - name: 2D on mIF example data
       run: |
-        miniature data/exemplar-001_small.tif output_mif_2D.png --n_components 2 --colormap TEULING2
+        miniature data/WD-76845-003_ROI01.ome.tif output_mif_2D.png --n_components 2 --colormap TEULING2
         test -f output_mif_2D.png || (echo "mIF output file not created" && exit 1)
 
     - name: Upload generated images as artifacts


### PR DESCRIPTION
This pull request updates the test workflow to use a different example data file for the 2D and 3D mIF tests. The new file is <4MB vs the 13MB original file.

Test data update:

* Updated the test commands in `.github/workflows/test-workflow.yml` to use `data/WD-76845-003_ROI01.ome.tif` instead of `data/exemplar-001_small.tif` for both 2D and 3D mIF example data tests.